### PR TITLE
fix - ansible-lint error install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ LABEL vendor2="Konstantin Deepezh aka D3pRe5s"
 RUN apk add --no-cache \
     python3 python3-dev py3-pip gcc git curl build-base autoconf automake \
     py3-cryptography linux-headers musl-dev libffi-dev openssl-dev openssh \
-    make 
+    make ansible-lint
 
 RUN pip install ansible && \
     pip install molecule && \
     pip install 'molecule[docker]' && \
     pip install 'molecule[vagrant]' && \
-    pip install yamllint && \
-    pip install ansible-lint
+    pip install yamllint
+#    pip install ansible-lint
 #    pip install --ignore-installed distlib==0.3.1 && \
 
 COPY molecule.yml /usr/lib/python3.8/site-packages/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}


### PR DESCRIPTION
**How to Install ansible-lint in Ubuntu 18.04**

Install ansible-lint by entering the following commands in the terminal:
```
sudo apt update
sudo apt install ansible-lint
```
[www.howtoinstall.me](https://www.howtoinstall.me/ubuntu/18-04/ansible-lint/)

```
❯ docker-image-molecule-main $ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
❯ docker-image-molecule-main $ docker images
REPOSITORY         TAG       IMAGE ID       CREATED          SIZE
d3pre5s/molecule   latest    ec846061af50   13 seconds ago   778MB
d3pre5s/molecule   <none>    2c4bce7d3f48   22 hours ago     963MB
❯ docker-image-molecule-main  $ docker run  -ti ec8 sh
/role # uname -a
Linux 67cfb6d640ed 6.1.14-100.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Sun Feb 26 00:31:11 UTC 2023 x86_64 Linux
```
